### PR TITLE
pytest driver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ xtesting.testcase =
     second = xtesting.samples.second:Test
     mts = xtesting.core.mts:MTSLauncher
     ansible = xtesting.core.ansible:Ansible
+    pytest = xtesting.core.pytest:Pytest
 
 [build_sphinx]
 all_files = 1

--- a/xtesting/core/pytest.py
+++ b/xtesting/core/pytest.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python3
+
+import logging
+import time
+
+import pytest
+import xtesting
+
+
+class Pytest(xtesting.core.testcase.TestCase):
+    """pytest runner."""
+
+    __logger = logging.getLogger(__name__)
+
+    def run(self, **kwargs):
+        try:
+            dir = kwargs.pop('dir')
+            options = kwargs.pop('options', [])
+        except KeyError as err:
+            self.__logger.exception(f"Missing args: {err.args[0]!r}")
+            return self.EX_RUN_ERROR
+        if kwargs:
+            self.__logger.exception(f"Unexpected args {kwargs}")
+            return self.EX_RUN_ERROR
+
+        self.start_time = time.time()
+
+        pytest.main(args=['--tb=no', '-p', 'xtesting.utils.pytesthooks'] + options + [dir])
+
+        self.stop_time = time.time()
+        self.details = xtesting.utils.pytesthooks.details
+        self.result = 100
+        return self.EX_OK

--- a/xtesting/core/pytest.py
+++ b/xtesting/core/pytest.py
@@ -53,10 +53,10 @@ class Pytest(xtesting.core.testcase.TestCase):
         # running pytest with 'options' in 'dir'
         #  the pytesthooks initiates an empty 'details' and populates it with individual test results
         self.start_time = time.time()
-        pytest.main(args=['--tb=no', '-p', 'xtesting.utils.pytesthooks'] + options + [dir])
+        pytest.main(args=[dir] + ['--tb=no', '-p', 'xtesting.utils.pytesthooks'] + options)
         self.stop_time = time.time()
 
         # fectching results in pytesthooks
         self.details = xtesting.utils.pytesthooks.details
         self.result = xtesting.utils.pytesthooks.result
-        return self.EX_OK if xtesting.utils.pytesthooks.ok else self.EX_NOK
+        return self.EX_OK

--- a/xtesting/core/pytest.py
+++ b/xtesting/core/pytest.py
@@ -40,9 +40,9 @@ class Pytest(xtesting.core.testcase.TestCase):
             dir = args.pop('dir')
             options = args.pop('options', [])
             if isinstance(options, dict):
-                options = [v for o in
-                           zip([f'--{k}' if len(str(k)) > 1 else f'-{k}' for k in options], options.values())
-                           for v in o if v is not None]
+                options = [str(item) for opt in
+                           zip([f'--{k}' if len(str(k)) > 1 else f'-{k}' for k in options.keys()], options.values())
+                           for item in opt if item is not None]
         except KeyError as err:
             self.logger.exception(f"Missing args: {err.args[0]!r}")
             return self.EX_RUN_ERROR

--- a/xtesting/utils/pytesthooks.py
+++ b/xtesting/utils/pytesthooks.py
@@ -4,21 +4,19 @@ details = None
 passed = None
 failed = None
 result = None
-ok = None
 
 
 def pytest_sessionstart(session):
-    global details, passed, failed, result, ok
+    global details, passed, failed, result
     details = dict(tests=[])
     passed = 0
     failed = 0
     result = 0
-    ok = True
 
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    global details, passed, failed, result, ok
+    global details, passed, failed, result
     outcome = yield
     outcome = outcome.get_result()
     if call.when == 'call':
@@ -27,7 +25,6 @@ def pytest_runtest_makereport(item, call):
             test = dict(status='PASSED', result=call.result)
         elif outcome == 'failed':
             failed += 1
-            ok = False
             test = dict(status='FAILED', result=call.excinfo)
         elif outcome == 'skipped':
             test = dict(status='SKIPPED', result=call.excinfo)

--- a/xtesting/utils/pytesthooks.py
+++ b/xtesting/utils/pytesthooks.py
@@ -1,25 +1,38 @@
 import pytest
 
 details = None
+passed = None
+failed = None
+result = None
+ok = None
 
 
 def pytest_sessionstart(session):
-    global details
+    global details, passed, failed, result, ok
     details = dict(tests=[])
+    passed = 0
+    failed = 0
+    result = 0
+    ok = True
 
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    global details
+    global details, passed, failed, result, ok
     outcome = yield
-    result = outcome.get_result()
-    if result.when == 'call':
-        if result.outcome == 'passed':
+    outcome = outcome.get_result()
+    if call.when == 'call':
+        if outcome == 'passed':
+            passed += 1
             test = dict(status='PASSED', result=call.result)
-        elif result.outcome == 'failed':
+        elif outcome == 'failed':
+            failed += 1
+            ok = False
             test = dict(status='FAILED', result=call.excinfo)
-        elif result.outcome == 'skipped':
+        elif outcome == 'skipped':
             test = dict(status='SKIPPED', result=call.excinfo)
         else:
             test = {}
+        if passed + failed:
+            result = passed / (passed + failed)
         details['tests'].append(test)

--- a/xtesting/utils/pytesthooks.py
+++ b/xtesting/utils/pytesthooks.py
@@ -31,5 +31,5 @@ def pytest_runtest_makereport(item, call):
         else:
             test = {}
         if passed + failed:
-            result = passed / (passed + failed)
+            result = passed / (passed + failed) * 100
         details['tests'].append(test)

--- a/xtesting/utils/pytesthooks.py
+++ b/xtesting/utils/pytesthooks.py
@@ -1,0 +1,25 @@
+import pytest
+
+details = None
+
+
+def pytest_sessionstart(session):
+    global details
+    details = dict(tests=[])
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    global details
+    outcome = yield
+    result = outcome.get_result()
+    if result.when == 'call':
+        if result.outcome == 'passed':
+            test = dict(status='PASSED', result=call.result)
+        elif result.outcome == 'failed':
+            test = dict(status='FAILED', result=call.excinfo)
+        elif result.outcome == 'skipped':
+            test = dict(status='SKIPPED', result=call.excinfo)
+        else:
+            test = {}
+        details['tests'].append(test)

--- a/xtesting/utils/pytesthooks.py
+++ b/xtesting/utils/pytesthooks.py
@@ -17,19 +17,15 @@ def pytest_sessionstart(session):
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     global details, passed, failed, result
-    outcome = yield
-    outcome = outcome.get_result()
-    if call.when == 'call':
-        if outcome == 'passed':
+    yreport = yield
+    report = yreport.get_result()
+    if report.when == 'call':
+        test = dict(name=report.nodeid, status=report.outcome.upper())
+        if report.passed:
             passed += 1
-            test = dict(status='PASSED', result=call.result)
-        elif outcome == 'failed':
+        elif report.failed:
             failed += 1
-            test = dict(status='FAILED', result=call.excinfo)
-        elif outcome == 'skipped':
-            test = dict(status='SKIPPED', result=call.excinfo)
-        else:
-            test = {}
+            test['failure'] = report.longreprtext
         if passed + failed:
             result = passed / (passed + failed) * 100
         details['tests'].append(test)


### PR DESCRIPTION
Here is proposition for a pytest driver

The 'pytest driver' can be used on every test set written for pytest.
Given a pytest package that is launched with the command: `pytest --opt1 arg1 --opt2 testdir`, it can be executed by xtesting with the following testcase.yaml:

```yaml
run:
  name: pytest
    args:
      dir: testdir
      options:
        opt1: arg1
        opt2: null
```

options can be written as a list of strings `['--opt1', 'arg1', '--opt2']`